### PR TITLE
adding grow command [ WIP]

### DIFF
--- a/supermercado/grow_tiles.py
+++ b/supermercado/grow_tiles.py
@@ -1,0 +1,31 @@
+from supermercado import super_utils as sutils
+import numpy as np
+
+
+def itergrow(burn, distance=1):
+    idxs = sutils.get_idx()
+
+    for g in range(distance):
+        burn = (np.max(np.dstack((
+            np.roll(np.roll(burn, i[0], 0), i[1], 1) for i in idxs
+            )), axis=2)) 
+
+    return burn
+
+def grow(inputtiles, parsenames, distance):
+    tiles = sutils.tile_parser(inputtiles, parsenames)
+
+    xmin, xmax, ymin, ymax = sutils.get_range(tiles)
+
+    zoom = sutils.get_zoom(tiles)
+
+    burn = sutils.burnXYZs(tiles, xmin, xmax, ymin, ymax, pad=distance+1)
+
+    xys_edge = itergrow(burn.copy(), distance) - burn
+
+    xys_edge = np.dstack(np.where(xys_edge))[0]
+    xys_edge[:, 0] += xmin - 1 - distance
+    xys_edge[:, 1] += ymin - 1 - distance
+
+
+    return np.append(xys_edge, np.zeros((xys_edge.shape[0], 1), dtype=np.uint8) + zoom, axis=1)

--- a/supermercado/scripts/cli.py
+++ b/supermercado/scripts/cli.py
@@ -1,6 +1,6 @@
 import click, json
 import cligj
-from supermercado import edge_finder, uniontiles, burntiles, super_utils
+from supermercado import edge_finder, uniontiles, burntiles, super_utils, grow_tiles
 
 
 @click.group('supermercado')
@@ -44,6 +44,24 @@ def union(inputtiles, parsenames):
 
 cli.add_command(union)
 
+@click.command('grow')
+@click.argument('inputtiles', default='-', required=False)
+@click.option('--distance', '-d', type=int, default=1, help='Degree to grow by [DEFAULT = 1]')
+@click.option('--parsenames', is_flag=True)
+def grow(inputtiles, parsenames, distance):
+    """
+    Grow a stream of [<x>, <y>, <z>] tiles in the x and y dimensions
+    """
+    try:
+        inputtiles = click.open_file(inputtiles).readlines()
+    except IOError:
+        inputtiles = [inputtiles]
+    grown = grow_tiles.grow(inputtiles, parsenames, distance)
+    for t in grown:
+        click.echo(json.dumps(t.tolist()))
+
+cli.add_command(grow)
+
 
 @click.command('burn')
 @cligj.features_in_arg
@@ -57,7 +75,7 @@ def burn(features, sequence, zoom):
 
     tiles = burntiles.burn(features, zoom)
     for t in tiles:
-        click.echo(t.tolist())
+        click.echo(json.dumps(t.tolist()))
 
 
 cli.add_command(burn)


### PR DESCRIPTION
In order to grow a list of tiles in the x and y dimensions.

A set of tiles:
```
cat data/ellada.geojson | supermercado burn 10 | mercantile shapes | fio collect | geojsonio
```
![image](https://cloud.githubusercontent.com/assets/5084513/20443544/1e14b6f4-ad82-11e6-9144-6f148d940ff2.png)

Grown by the default, 1:
```
cat data/ellada.geojson | supermercado burn 10 | supermercado grow | mercantile shapes | fio collect | geojsonio 
```
![image](https://cloud.githubusercontent.com/assets/5084513/20443580/418c91ce-ad82-11e6-87a9-1996ac56cd95.png)

Grown by 10:
```
cat data/ellada.geojson | supermercado burn 10 | supermercado grow --distance 10 | mercantile shapes | fio collect | geojsonio
```
![image](https://cloud.githubusercontent.com/assets/5084513/20443603/59d1bb06-ad82-11e6-9062-21ed57036093.png)

Just return the new growth:
```
cat data/ellada.geojson | supermercado burn 10 | supermercado grow -n | mercantile shapes | fio collect | geojsonio
```
![image](https://cloud.githubusercontent.com/assets/5084513/20443629/747b8ffe-ad82-11e6-99b5-293619ff2f89.png)

Needs:
- [ ] Cleanup (namespace / opts are a little messy)
- [ ] Tests
- [ ] Documentation