### PR TITLE
remove unused modules

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,6 @@ affine
 click
 click-plugins
 cligj
-enum34
 mercantile
 numpy
-pyparsing
 rasterio
-snuggs
-wheel


### PR DESCRIPTION
This PR removes unused modules from `requirements.txt` especially `enum34` 

cc @dnomadb @sgillies 