### PR TITLE
Use Codecov Bash Uploader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,4 +52,4 @@ script:
   - py.test --cov supermercado --cov-report term-missing -vv
 
 after_success:
-  - codecov
+  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Use [Codecov Bash Uploader](https://docs.codecov.io/v4.3.0/docs/about-the-codecov-bash-uploader#section-upload-token) to avoid setting up a env variable.