### PR TITLE
Replace np subtract operator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
 
 python:
-  - "2.7"
+  - "3.6"
 
 addons:
   apt:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ click-plugins
 cligj
 mercantile
 numpy
+pytest
 rasterio

--- a/supermercado/edge_finder.py
+++ b/supermercado/edge_finder.py
@@ -23,7 +23,7 @@ def findedges(inputtiles, parsenames):
     # Using the indices to roll + stack the array, find the minimum along the rolled / stacked axis
     xys_edge = (np.min(np.dstack((
         np.roll(np.roll(burn, i[0], 0), i[1], 1) for i in idxs
-        )), axis=2) - burn)
+        )), axis=2) ^ burn)
 
     # Set missed non-tiles to False
     xys_edge[burn == False] = False


### PR DESCRIPTION
This PR fix the following Numpy error

```
TypeError: numpy boolean subtract, the `-` operator, is deprecated, use the bitwise_xor, the `^` operator, or the logical_xor function instead.
```