### PR TITLE
Fix the source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
+include LICENSE
+include README.md
 include requirements.txt


### PR DESCRIPTION
Latest source distribution release on PyPI cannot be installed b/c the setup.py reads from the README.md but the file is absent in the tarball.

This PR also includes the license file so downstream packager can comply with the license requirements. 